### PR TITLE
break Dockerfile test CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # Use official Python base image
-FROM python:3.11-slim
+FROM pythonnnnnnnnnnnnnnnnnnnnnnnn:3.11-slim
+
 
 # Set work directory
 WORKDIR /app


### PR DESCRIPTION
This PR introduces an issue in the Dockerfile by specifying a non-existent or invalid Python base image version, pythonnnnnnnnnnnnnnnnnnnnnnnn:3.11-slim. The image name is misspelled and does not exist in the Docker Hub registry. As a result, the Docker build will fail during the FROM stage due to the inability to pull the specified image.

Details:
The correct base image should be python:3.11-slim, but the image in the Dockerfile has an invalid and exaggerated name (pythonnnnnnnnnnnnnnnnnnnnnnnn), which causes the build process to fail.

This error needs to be corrected to restore the functionality of the Dockerfile.